### PR TITLE
シェアボタンを追加した

### DIFF
--- a/app/javascript/packs/share.js
+++ b/app/javascript/packs/share.js
@@ -2,12 +2,17 @@ const main = async () => {
   const gif_dom = document.querySelector('#gif');
   if (!gif_dom) return;
 
+  const share_button = document.querySelector('#share-button');
+  if (!navigator.share) {
+    share_button.style.display = 'none';
+    return;
+  }
+
   const title = document.querySelector('.title').innerText;
   const res = await fetch(gif_dom.src);
   const blob = await res.blob();
   const file = new File([blob], 'file.gif', { type: 'image/gif' });
 
-  const share_button = document.querySelector('#share-button');
   share_button.addEventListener('click', () => {
     try {
       navigator.share({

--- a/app/javascript/packs/share.js
+++ b/app/javascript/packs/share.js
@@ -1,0 +1,24 @@
+const main = async () => {
+  const gif_dom = document.querySelector('#gif');
+  if (!gif_dom) return;
+
+  const title = document.querySelector('.title').innerText;
+  const res = await fetch(gif_dom.src);
+  const blob = await res.blob();
+  const file = new File([blob], 'file.gif', { type: 'image/gif' });
+
+  const share_button = document.querySelector('#share-button');
+  share_button.addEventListener('click', () => {
+    try {
+      navigator.share({
+        text: title,
+        url: location.href,
+        files: [file],
+      });
+    } catch (e) {
+      console.warn('Your device does not support navigator.share :(');
+    }
+  });
+};
+
+main();

--- a/app/views/gifs/show.html.erb
+++ b/app/views/gifs/show.html.erb
@@ -1,9 +1,11 @@
+<%= javascript_pack_tag 'share', defer: true %>
+
 <% description "vGIFにアップロードされたGIF、「#{@gif.title}」のページ - VTuberのGIFが集まる場所、vGIF" %>
 <% keywords @gif.tag_list.join(',') %>
 <% set_meta_tags og: { image: image_public_url(ogp_image(@gif.image)) } %>
 <% set_meta_tags twitter: { card: 'summary_large_image' } %>
 
-<%= image_tag @gif.image %>
+<%= image_tag @gif.image, id: 'gif' %>
 
 <div class="content">
   <p class="title is-3 is-inline"><%= title @gif.title %></p>
@@ -50,12 +52,12 @@
 </div>
 
 <div class="field">
-  <a class="button is-info is-small" href="<%= tweet_url(@gif.title, gif_url(@gif)) %>" target="_blank" rel="ugc noopenner noreferrer">
+  <button id="share-button" class="button is-primary is-small">
     <span class="icon">
-      <i class="fab fa-twitter"></i>
+      <i class="fas fa-share-alt-square"></i>
     </span>
-    <span>Tweet</span>
-  </a>
+    <span>Share</span>
+  </button>
 </div>
 
 <div class="content">


### PR DESCRIPTION
close #15 

navigator.shareを使用してGIFをシェアできるようにした。

Web Share - Level 2に対応したブラウザ、例えばAndroid向けのモバイル版Chromeでは、TwitterにAnimated GIFをツイートできる！
Level 2に対応していないiOSのSafariでは、文章とURLのツイートだけできる。